### PR TITLE
Add flake.nix + adjustments to run with Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,37 @@ pip install -r requirements.txt
 python kivra_sync.py YYYYMMDDXXXX
 ```
 
+### Option 3: Using Nix (flake)
+
+If you have Nix with flakes enabled:
+
+```bash
+# Run (uses the flake-provided environment)
+nix run . -- --help
+
+# Typical run, storing under ./data/<ssn>/
+nix run . -- YYYYMMDDXXXX --base-dir ./data
+
+# Run with the web interaction provider
+nix run . -- YYYYMMDDXXXX --interaction-provider web --web-port 8080
+
+# Dev shell with Python + deps + system libs
+nix develop
+
+```
+
+Notes:
+- The flake bundles WeasyPrint and its system libraries.
+- Temp files are written to a writable location; see “Paths and Environment Variables”.
+- You can override the base directory with `--base-dir` or `KIVRA_SYNC_BASE_DIR`.
+
 ## Advanced Configuration
 
 ### Storage Providers
 
 #### Filesystem Storage (Default)
 
-Documents are stored in the local filesystem:
+Documents are stored in the local filesystem. By default, the base directory is the current working directory (can be overridden with `--base-dir` or `KIVRA_SYNC_BASE_DIR`):
 
 ```bash
 python kivra_sync.py YYYYMMDDXXXX --storage-provider filesystem --base-dir /path/to/store
@@ -138,7 +162,7 @@ python kivra_sync.py YYYYMMDDXXXX --max-receipts 0
 | Option | Description |
 |--------|-------------|
 | `--storage-provider {filesystem,paperless}` | Storage provider to use (default: filesystem) |
-| `--base-dir DIR` | Base directory for storing documents (default: script directory) |
+| `--base-dir DIR` | Base directory for storing documents (default: current working directory) |
 
 ### Paperless-specific Options
 | Option | Description |
@@ -166,6 +190,15 @@ python kivra_sync.py YYYYMMDDXXXX --max-receipts 0
 | `--fetch-letters` / `--no-fetch-letters` | Enable/disable letter fetching (default: enabled) |
 | `--max-receipts N` | Maximum number of receipts to fetch (0 for unlimited) |
 | `--max-letters N` | Maximum number of letters to fetch (0 for unlimited) |
+
+### Paths and Environment Variables
+| Variable | Description |
+|----------|-------------|
+| `KIVRA_SYNC_BASE_DIR` | Default base directory when using the filesystem storage provider. Equivalent to `--base-dir`. |
+| `KIVRA_SYNC_TEMP_DIR` | Directory for temporary files (e.g., QR codes). If not set, falls back to `XDG_RUNTIME_DIR` or the OS temp directory. |
+
+Notes:
+- When running from read-only installations (e.g., Nix), the application uses a writable temp directory (as above) and defaults the filesystem base directory to the current working directory unless `--base-dir`/`KIVRA_SYNC_BASE_DIR` is provided.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -191,15 +191,6 @@ python kivra_sync.py YYYYMMDDXXXX --max-receipts 0
 | `--max-receipts N` | Maximum number of receipts to fetch (0 for unlimited) |
 | `--max-letters N` | Maximum number of letters to fetch (0 for unlimited) |
 
-### Paths and Environment Variables
-| Variable | Description |
-|----------|-------------|
-| `KIVRA_SYNC_BASE_DIR` | Default base directory when using the filesystem storage provider. Equivalent to `--base-dir`. |
-| `KIVRA_SYNC_TEMP_DIR` | Directory for temporary files (e.g., QR codes). If not set, falls back to `XDG_RUNTIME_DIR` or the OS temp directory. |
-
-Notes:
-- When running from read-only installations (e.g., Nix), the application uses a writable temp directory (as above) and defaults the filesystem base directory to the current working directory unless `--base-dir`/`KIVRA_SYNC_BASE_DIR` is provided.
-
 ## Project Structure
 
 The code is organized into logical modules:

--- a/README.md
+++ b/README.md
@@ -63,15 +63,13 @@ nix run . -- YYYYMMDDXXXX --base-dir ./data
 # Run with the web interaction provider
 nix run . -- YYYYMMDDXXXX --interaction-provider web --web-port 8080
 
+# Build and run help on resulting executable
+nix build && result/bin/kivra-sync --help 
+
 # Dev shell with Python + deps + system libs
 nix develop
 
 ```
-
-Notes:
-- The flake bundles WeasyPrint and its system libraries.
-- Temp files are written to a writable location; see “Paths and Environment Variables”.
-- You can override the base directory with `--base-dir` or `KIVRA_SYNC_BASE_DIR`.
 
 ## Advanced Configuration
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ nix develop
 
 #### Filesystem Storage (Default)
 
-Documents are stored in the local filesystem. By default, the base directory is the current working directory (can be overridden with `--base-dir` or `KIVRA_SYNC_BASE_DIR`):
+Documents are stored in the local filesystem. 
 
 ```bash
 python kivra_sync.py YYYYMMDDXXXX --storage-provider filesystem --base-dir /path/to/store

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1756819007,
+        "narHash": "sha256-12V64nKG/O/guxSYnr5/nq1EfqwJCdD2+cIGmhz3nrE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aaff8c16d7fc04991cac6245bee1baa31f72b1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,129 @@
+{
+  description = "Kivra Sync - Nix flake to build and develop the project";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }: let
+    systems = [ "x86_64-linux" "aarch64-linux" ];
+    forAllSystems = f: builtins.listToAttrs (map (system: {
+      name = system;
+      value = f system;
+    }) systems);
+  in {
+    packages = forAllSystems (system: let
+      pkgs = import nixpkgs { inherit system; }; 
+      lib = pkgs.lib;
+      py = pkgs.python3;
+      pyPkgs = pkgs.python3Packages;
+    in {
+      default = pyPkgs.buildPythonApplication {
+        pname = "kivra-sync";
+        version = self.rev or "dev";
+        src = ./.;
+
+        format = "other"; # custom installPhase, no setuptools/poetry
+        dontUseSetuptools = true;
+
+        propagatedBuildInputs = with pyPkgs; [
+          pillow
+          qrcode
+          requests
+          weasyprint
+        ];
+
+        # System libraries required by WeasyPrint/Pango/Cairo at runtime
+        buildInputs = with pkgs; [
+          cairo
+          pango
+          harfbuzz
+          freetype
+          fontconfig
+          gdk-pixbuf
+          libxml2
+          libxslt
+          glib
+          fribidi
+        ];
+
+        nativeBuildInputs = [ pkgs.makeWrapper ];
+
+        installPhase = ''
+          runHook preInstall
+
+          site="${py.sitePackages}"
+          mkdir -p "$out/$site" "$out/bin"
+
+          # Install python modules
+          cp -r kivra interaction storage utils "$out/$site/"
+          cp __version__.py "$out/$site/"
+          cp kivra_sync.py "$out/$site/kivra_sync.py"
+
+          # Entry point
+          cat > "$out/bin/kivra-sync" << 'EOF'
+          #!${py.interpreter}
+          import sys
+          from kivra_sync import main
+          if __name__ == "__main__":
+              sys.exit(main())
+          EOF
+          chmod +x "$out/bin/kivra-sync"
+
+          runHook postInstall
+        '';
+
+        # Ensure CFFI can dlopen pango/cairo and friends at runtime
+        postFixup = let
+          libPath = lib.makeLibraryPath [
+            pkgs.pango
+            pkgs.cairo
+            pkgs.gdk-pixbuf
+            pkgs.harfbuzz
+            pkgs.freetype
+            pkgs.fontconfig
+            pkgs.fribidi
+            pkgs.glib
+            pkgs.libxml2
+            pkgs.libxslt
+          ];
+        in ''
+          wrapProgram "$out/bin/kivra-sync" \
+            --prefix LD_LIBRARY_PATH : ${lib.escapeShellArg libPath}
+        '';
+
+        meta = with lib; {
+          description = "Automation tool to sync documents from Kivra";
+          homepage = "https://github.com/";
+          license = licenses.mit;
+          platforms = platforms.linux;
+          mainProgram = "kivra-sync";
+        };
+      };
+    });
+
+    apps = forAllSystems (system: {
+      default = {
+        type = "app";
+        program = "${self.packages.${system}.default}/bin/kivra-sync";
+      };
+    });
+
+    devShells = forAllSystems (system: let
+      pkgs = import nixpkgs { inherit system; };
+      pyEnv = pkgs.python3.withPackages (ps: with ps; [
+        pillow qrcode requests weasyprint
+      ]);
+    in {
+      default = pkgs.mkShell {
+        packages = [
+          pyEnv
+          # Useful system libs for WeasyPrint during development
+          pkgs.cairo pkgs.pango pkgs.harfbuzz pkgs.freetype pkgs.fontconfig pkgs.gdk-pixbuf
+          pkgs.libxml2 pkgs.libxslt pkgs.glib pkgs.fribidi
+          # Optional: node for release tooling in package.json
+          pkgs.nodejs
+        ];
+      };
+    });
+  };
+}
+

--- a/kivra_sync.py
+++ b/kivra_sync.py
@@ -130,8 +130,7 @@ def main():
     # Prefer env overrides and OS temp; avoid writing into read-only installs
     script_dir = os.path.dirname(os.path.abspath(__file__))
     temp_base = (
-        os.environ.get("KIVRA_SYNC_TEMP_DIR")
-        or os.environ.get("XDG_RUNTIME_DIR")
+        os.environ.get("XDG_RUNTIME_DIR")
         or tempfile.gettempdir()
     )
     temp_dir = os.path.join(temp_base, "kivra-sync")
@@ -143,8 +142,7 @@ def main():
         base_dir = (
             args.base_dir
             if args.base_dir
-            else os.environ.get("KIVRA_SYNC_BASE_DIR")
-            or os.getcwd()
+            else os.getcwd()
         )
         document_store = FileSystemStoreProvider(os.path.join(base_dir, args.ssn), dry_run=args.dry_run)
     elif args.storage_provider == 'paperless':


### PR DESCRIPTION
This small patch adds a flake.nix + lockfile to run the program with Nix. In addition to the flake file itself, it also includes small adjustments neccessary since Nix installs the program to the read-only Nix store directory tree, so it can't create a temp dir in that directory. This part of the patch may be overly complex, but I supply it as-is

Transparency: The patch was created with help from Codex CLI. 
